### PR TITLE
Fix errors after numerics reform

### DIFF
--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Servo Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::num::Float;
 
 /// Trait for testing approximate equality
 pub trait ApproxEq<Eps> {

--- a/src/length.rs
+++ b/src/length.rs
@@ -10,7 +10,7 @@
 
 use scale_factor::ScaleFactor;
 
-use std::num::{cast, Zero};
+use std::num::{cast, NumCast, Zero};
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
 ///

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Servo Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -11,7 +11,7 @@ use length::Length;
 use size::Size2D;
 
 use std::fmt;
-use std::num::Zero;
+use std::num::{NumCast, Zero};
 
 #[deriving(Clone, Decodable, Encodable, Eq, Hash, PartialEq)]
 pub struct Point2D<T> {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Servo Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -13,7 +13,7 @@ use point::Point2D;
 use size::Size2D;
 use std::cmp::{PartialEq, PartialOrd};
 use std::fmt;
-use std::num::Zero;
+use std::num::{NumCast, Zero};
 
 #[deriving(Clone, Decodable, Encodable, PartialEq)]
 pub struct Rect<T> {

--- a/src/scale_factor.rs
+++ b/src/scale_factor.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 //! A type-checked scaling factor between units.
 
-use std::num::{cast, One};
+use std::num::{cast, NumCast, One};
 
 /// A scaling factor between two different units of measurement.
 ///

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Servo Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -10,7 +10,7 @@
 //! A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 //! and margins in CSS.
 
-use std::num::Zero;
+use std::num::{Num, Zero};
 
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS.

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Servo Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -11,7 +11,7 @@ use length::Length;
 
 use std::cmp::PartialEq;
 use std::fmt;
-use std::num::Zero;
+use std::num::{NumCast, Zero};
 
 #[deriving(Clone, Decodable, Encodable, PartialEq)]
 pub struct Size2D<T> {


### PR DESCRIPTION
There are still lots of warnings about `Zero` and `One` being deprecated, but I do not see an easy way of resolving those without splitting everything in a `Float` and an `Int` case.