### PR TITLE
Remove redundant steps in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,2 @@
 language: rust
 sudo: false
-
-script:
-  - cargo build
-  - cargo test


### PR DESCRIPTION
These are the default steps anyways, so no point in explicitly listing
them.

http://docs.travis-ci.com/user/languages/rust/